### PR TITLE
Adding an import from local_settings.py if available

### DIFF
--- a/wikilegis/settings.py
+++ b/wikilegis/settings.py
@@ -291,3 +291,8 @@ EMAIL_PORT = config('EMAIL_PORT', cast=int, default=587)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', cast=bool, default=True)
+
+try:
+    from local_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
According to this http://stackoverflow.com/questions/4909958/django-local-settings question in StackOverflow one can use a local_settings.py to override the previously set settings in settings.py
